### PR TITLE
Feature: Optiongroups

### DIFF
--- a/genesis-widget-column-classes.php
+++ b/genesis-widget-column-classes.php
@@ -418,6 +418,48 @@ final class WCC_Genesis_Widget_Column_Classes
 	}
 
 	/**
+	 * Sort column classes based on selection.
+	 *
+	 * @since   1.4.0
+	 * @access  public
+	 * @param   array  $classes
+	 * @param   array  $selected
+	 * @return  array
+	 */
+	public function sort_selected_column_classes( $classes, $selected ) {
+		$values = array();
+		$groups = array();
+
+		// Separate option groups from single values.
+		foreach ( $classes as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$groups[ $key ] = $value;
+			} else {
+				$values[ $key ] = $value;
+			}
+		}
+
+		// Same keys as values.
+		$values   = array_combine( $values, $values );
+		$selected = array_combine( $selected, $selected );
+
+		foreach ( $selected as $class ) {
+			// Remove from groups.
+			foreach ( $groups as $group => $classes ) {
+				$key = array_search( $class, $classes, true );
+				if ( false !== $key ) {
+					unset( $groups[ $group ][ $key ] );
+				}
+			}
+		}
+
+		// Selected first.
+		$values = array_replace( $selected, $values );
+
+		return array_merge( $values, $groups );
+	}
+
+	/**
 	 * Add the new fields to the update instance.
 	 *
 	 * @since   0.1.0

--- a/genesis-widget-column-classes.php
+++ b/genesis-widget-column-classes.php
@@ -391,15 +391,13 @@ final class WCC_Genesis_Widget_Column_Classes
 			}
 			$class_names = (array) $class_names;
 			$options     = '';
-			foreach ( $class_names as $class_name ) {
-				if ( ! empty( $class_name ) ) {
-					$class_label = $class_name;
-					$selected    = in_array( $class_name, $instance['column-classes'], true );
-					if ( $this->select_multiple ) {
-						$options .= '<label><input type="checkbox" name="' . $field_name . '[]" value="' . $class_name . '" ' . checked( $selected, true, false ) . '> ' . $class_label . '</label>';
-					} else {
-						$options .= '<option value="' . $class_name . '" ' . selected( $selected, true, false ) . '>' . $class_label . '</option>';
-					}
+			foreach ( array_filter( $class_names ) as $class_name ) {
+				$class_label = $class_name;
+				$selected    = in_array( $class_name, $instance['column-classes'], true );
+				if ( $this->select_multiple ) {
+					$options .= '<label><input type="checkbox" name="' . $field_name . '[]" value="' . $class_name . '" ' . checked( $selected, true, false ) . '> ' . $class_label . '</label>';
+				} else {
+					$options .= '<option value="' . $class_name . '" ' . selected( $selected, true, false ) . '>' . $class_label . '</option>';
 				}
 			}
 			if ( $options ) {


### PR DESCRIPTION
Adds a simple method for creation option groups for custom column classes.

**For multiselect:**
Selected columns will still be shown **as first** and **outside of the group** to be able to easily find active columns and deselect them if needed.

**Format:**
```php
// Array key is the group label.
array(
	'One' => array(
		'one-half',
		'one-third',
		'one-fourth',
		'one-fifth',
		'one-sixth',
		'one-seventh',
		'one-eighth',
	),
	'Two' => array(
		'two-thirds',
		'two-fourths',
		'two-fifths',
		'two-sixths',
		'two-sevenths',
		'two-eighths',
	),
	// Etc.
);
```